### PR TITLE
Updated Magento 2 nginx setting

### DIFF
--- a/playbooks/roles/env/local/templates/m2.j2
+++ b/playbooks/roles/env/local/templates/m2.j2
@@ -145,7 +145,8 @@ server {
     location ~ (index|get|static|report|404|503|health_check)\.php$ {
         try_files $uri =404;
         fastcgi_pass unix:/var/run/php/{{ php_version }}.sock;
-        fastcgi_buffers 1024 4k;
+        fastcgi_buffers 16 1024k; 
+        fastcgi_buffer_size 1024k
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
         fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";


### PR DESCRIPTION
- Fixed max FastCGI header too big, common issue when using xdebug